### PR TITLE
Return 401 for signed-but-invalid inbox requests while preserving unsigned fallback behavior

### DIFF
--- a/test/activity_pub/federator/activity_pub_controller_test.exs
+++ b/test/activity_pub/federator/activity_pub_controller_test.exs
@@ -501,6 +501,42 @@ defmodule ActivityPub.Web.ActivityPubControllerTest do
       assert Object.get_cached!(ap_id: data["id"])
     end
 
+    test "it returns 401 for signed but invalid activities", %{conn: conn} do
+      data = file("fixtures/mastodon/mastodon-post-activity.json") |> Jason.decode!()
+      subject = actor(local: false)
+
+      data =
+        data
+        |> Map.put("actor", subject.data["id"])
+
+      conn =
+        conn
+        |> assign(:valid_signature, false)
+        |> put_req_header("signature", "keyId=\"#{subject.data["id"]}/main-key\"")
+        |> put_req_header("content-type", "application/activity+json")
+        |> post("#{Utils.ap_base_url()}/shared_inbox", data)
+
+      assert json_response(conn, 401) == %{"error" => "invalid HTTP signature"}
+    end
+
+    test "it returns 401 when signature-input is present and signature is invalid", %{conn: conn} do
+      data = file("fixtures/mastodon/mastodon-post-activity.json") |> Jason.decode!()
+      subject = actor(local: false)
+
+      data =
+        data
+        |> Map.put("actor", subject.data["id"])
+
+      conn =
+        conn
+        |> assign(:valid_signature, false)
+        |> put_req_header("signature-input", "sig1=(\"@method\");created=1234567890")
+        |> put_req_header("content-type", "application/activity+json")
+        |> post("#{Utils.ap_base_url()}/shared_inbox", data)
+
+      assert json_response(conn, 401) == %{"error" => "invalid HTTP signature"}
+    end
+
     @tag capture_log: true
     test "it inserts an incoming activity into the database" <>
            "even if we can't fetch the user but have it in our db",


### PR DESCRIPTION
## Summary

This change tightens inbox response semantics for invalid signatures while preserving existing unverified fallback behavior for unsigned requests.

It returns `401` when `valid_signature` is `false` and the request contains HTTP signature headers (`signature` or `signature-input`), and it keeps the current unverified/fetch fallback path for truly unsigned requests.

It also adds regression tests for signed-invalid requests on `/shared_inbox`, covering both legacy `signature` and RFC 9421 `signature-input` header presence.

## Why

Some sender implementations try one signature style first and only retry with an alternate style when they receive an explicit failure response.

When signed-but-invalid requests are accepted with a success response, that retry path can be suppressed, which reduces interoperability.

Returning `401` for signed-but-invalid requests provides a clearer protocol signal and better compatibility while preserving existing behavior for unsigned traffic.

## Behavior change

Before: signed + invalid → success response and unverified fallback processing.

Before: unsigned → unverified fallback processing.

After: signed + invalid → `401 {"error":"invalid HTTP signature"}`.

After: unsigned → unchanged unverified fallback processing.

## Notes

This does intentionally change inbox behavior for signed-but-invalid requests, and I am opening this PR to validate whether this stricter response improves interoperability in practice.

If maintainers think this is too strict or causes regressions for existing federation behavior, I am fully okay with revising the approach or closing this PR.

## Tests

Added test: `it returns 401 for signed but invalid activities`.

Added test: `it returns 401 when signature-input is present and signature is invalid`.

## References

Closes #8.